### PR TITLE
Deploy action ERR WIP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,8 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    working-directory: ./lfg_bot
     env:
-      FLY_PROJECT_PATH: ./lfg_bot
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
ERR WIP: try using working-directory instead of FLY_PROJECT_PATH

Error: the config for your app is missing an app name, add an app field to the fly.toml file or specify with the -a flag