### PR TITLE
ERR WIP: try setting auto start to true, but leaving auto stop on false

### DIFF
--- a/lfg_bot/fly.toml
+++ b/lfg_bot/fly.toml
@@ -21,7 +21,7 @@ swap_size_mb = 512
   internal_port = 8080
   force_https = true
   auto_stop_machines = false
-  auto_start_machines = false
+  auto_start_machines = true
   min_machines_running = 0
   processes = ["app"]
   [http_service.concurrency]


### PR DESCRIPTION
Error: deploy seemed to go fine, but machine did not restart. May have been due to failing migrations.