### PR TITLE
Global commands MIGRATION PT.1

### DIFF
--- a/lfg_bot/lib/lfg_bot/discord/command_handlers.ex
+++ b/lfg_bot/lib/lfg_bot/discord/command_handlers.ex
@@ -1,0 +1,72 @@
+defmodule LfgBot.Discord.CommandHandlers do
+  require Logger
+  import Bitwise
+
+  alias Nostrum.Api, as: DiscordAPI
+  alias LfgBot.Discord.Consumer
+  alias LfgBot.LfgSystem
+  alias LfgBot.LfgSystem.{Session, RegisteredGuildChannel}
+  alias Nostrum.Struct.{Interaction, User, Message, Embed}
+  alias Nostrum.Struct.Component.{ActionRow, Button}
+  alias Nostrum.Snowflake
+  alias Nostrum.Struct.{ApplicationCommandInteractionData, Interaction}
+  alias LfgBot.Discord.{InteractionHandlers, CommandHandlers, MessageHandlers}
+
+  # INFO: @command_name defined as a module attribute so it can be pattern matched
+
+  @command_name_init "init"
+  @command_details_init %{
+    name: @command_name_init,
+    description: "Set up LFG Bot in the current channel"
+  }
+
+  def install_global_commands() do
+    global_commands = [
+      @command_details_init
+    ]
+
+    {:ok, _commands} = DiscordAPI.bulk_overwrite_global_application_commands(global_commands)
+    {:ok}
+  end
+
+  def install_guild_commands(_guilds) do
+    {:not_implemented}
+  end
+
+  def delete_all_global_commands() do
+    {:ok, commands} = DiscordAPI.get_global_application_commands()
+
+    for %{id: command_id} <- commands do
+      DiscordAPI.delete_global_application_command(command_id)
+    end
+
+    {:ok}
+  end
+
+  def delete_all_guild_commands(guild_id) do
+    {:ok, commands} = DiscordAPI.get_guild_application_commands(guild_id)
+
+    for %{id: command_id} <- commands do
+      DiscordAPI.delete_guild_application_command(guild_id, command_id)
+    end
+
+    {:ok}
+  end
+
+  # -----
+
+  def handle_command(
+        %Interaction{
+          channel_id: channel_id,
+          guild_id: guild_id,
+          user: %{id: invoker_user_id, username: invoker_user_name},
+          data: %ApplicationCommandInteractionData{name: @command_name_init}
+        } = interaction
+      ) do
+    Logger.debug(
+      "[DISCORD EVENT] [REGISTER CHANNEL] invoker: #{invoker_user_name} #{invoker_user_id} | guild id: #{guild_id}"
+    )
+
+    {:ok} = InteractionHandlers.register_channel(interaction, guild_id, channel_id)
+  end
+end

--- a/lfg_bot/lib/lfg_bot/discord/consumer.ex
+++ b/lfg_bot/lib/lfg_bot/discord/consumer.ex
@@ -214,11 +214,6 @@ defmodule LfgBot.Discord.Consumer do
       ) do
     [{"bot_user_id", bot_user_id}] = :ets.lookup(:lfg_bot_table, "bot_user_id")
 
-    # TODO: remove dbg
-    # TODO: remove dbg
-    # TODO: remove dbg
-    dbg(bot_user_id)
-
     if author_id == bot_user_id do
       {:ok} = MessageHandlers.registration_message(reg_id, channel_id, message_id)
     end

--- a/lfg_bot/lib/lfg_bot/discord/consumer.ex
+++ b/lfg_bot/lib/lfg_bot/discord/consumer.ex
@@ -3,37 +3,21 @@ defmodule LfgBot.Discord.Consumer do
   require Logger
 
   alias Nostrum.Struct.{ApplicationCommandInteractionData, Interaction}
-  alias LfgBot.Discord.{InteractionHandlers, MessageHandlers}
+  alias LfgBot.Discord.{InteractionHandlers, CommandHandlers, MessageHandlers}
 
   # bot permissions = send messages, create public threads, manage threads, read message history, add reactions, use slash commands
   # @bot_invite_url "https://discord.com/api/oauth2/authorize?client_id=1160972219061645312&permissions=53687158848&scope=bot"
-
-  # @command_name defined as a module attribute so it can be matched on
-  @command_name "lfginit"
-  def command_name, do: @command_name
 
   ## Interaction Handlers
   ## ----------------
 
   def handle_event({:READY, %{guilds: guilds, user: %{id: bot_user_id, bot: true}}, _ws_state}) do
-    Logger.debug("[DISCORD EVENT] [READY] installing server commands...")
-    {:ok} = InteractionHandlers.install_server_commands(guilds, bot_user_id)
-  end
+    # store bot user ID in ETS for later reference. Our code should be able to find out our ID at any time.
+    true = :ets.insert(:lfg_bot_table, {"bot_user_id", bot_user_id})
 
-  def handle_event(
-        {:INTERACTION_CREATE,
-         %Interaction{
-           channel_id: channel_id,
-           guild_id: guild_id,
-           user: %{id: invoker_user_id, username: invoker_user_name},
-           data: %ApplicationCommandInteractionData{name: @command_name}
-         } = interaction, _}
-      ) do
-    Logger.debug(
-      "[DISCORD EVENT] [REGISTER CHANNEL] invoker: #{invoker_user_name} #{invoker_user_id} | guild id: #{guild_id}"
-    )
-
-    {:ok} = InteractionHandlers.register_channel(interaction, guild_id, channel_id)
+    Logger.debug("[DISCORD EVENT] [READY] installing commands...")
+    {:ok} = CommandHandlers.install_global_commands()
+    {:not_implemented} = CommandHandlers.install_guild_commands(guilds)
   end
 
   def handle_event(
@@ -182,6 +166,23 @@ defmodule LfgBot.Discord.Consumer do
     {:ok} = InteractionHandlers.kick_player(interaction, invoker_id, session_id, user_id)
   end
 
+  ## Command Handlers
+  ## ----------------
+
+  def handle_event(
+        {:INTERACTION_CREATE,
+         %Interaction{
+           data: %ApplicationCommandInteractionData{}
+         } = interaction, _}
+      ) do
+    # INFO: we forward all commands to the command handler module,
+    #       rather than explicitly handling them here in the consumer like everything else.
+    #       The reason for this is that the CommandHandlers module has module attributes for
+    #       each of our command names, so they can be pattern matched on.
+    #       To use them here in the consumer, we'd have to duplicate that code into this module.
+    CommandHandlers.handle_command(interaction)
+  end
+
   ## Message Handlers
   ## ----------------
 
@@ -195,6 +196,11 @@ defmodule LfgBot.Discord.Consumer do
          }, _ws_state}
       ) do
     [{"bot_user_id", bot_user_id}] = :ets.lookup(:lfg_bot_table, "bot_user_id")
+
+    # TODO: remove dbg
+    # TODO: remove dbg
+    # TODO: remove dbg
+    dbg(bot_user_id)
 
     if author_id == bot_user_id do
       {:ok} = MessageHandlers.registration_message(reg_id, channel_id, message_id)

--- a/lfg_bot/lib/lfg_bot/discord/consumer.ex
+++ b/lfg_bot/lib/lfg_bot/discord/consumer.ex
@@ -16,8 +16,25 @@ defmodule LfgBot.Discord.Consumer do
     true = :ets.insert(:lfg_bot_table, {"bot_user_id", bot_user_id})
 
     Logger.debug("[DISCORD EVENT] [READY] installing commands...")
-    {:ok} = CommandHandlers.install_global_commands()
-    {:not_implemented} = CommandHandlers.install_guild_commands(guilds)
+
+    # DANGER: TEMP -------------------------------------------------------------
+    # SECTION: reset all commands migration:
+    #       we're migrating from guild commands to global commands, since we can
+    #       easily bulk update those.
+    #       after a deployed version deletes all commands, enable the code to install global commands.
+
+    {:ok} = CommandHandlers.delete_all_global_commands()
+
+    for %{id: guild_id} <- guilds do
+      {:ok} = CommandHandlers.delete_all_guild_commands(guild_id)
+    end
+
+    # END: reset all commands migration
+    # DANGER: TEMP -------------------------------------------------------------
+
+    # NOTE: enable the lines below after the migration.
+    # {:ok} = CommandHandlers.install_global_commands()
+    # {:not_implemented} = CommandHandlers.install_guild_commands(guilds)
   end
 
   def handle_event(

--- a/lfg_bot/lib/lfg_bot/discord/interaction_handlers.ex
+++ b/lfg_bot/lib/lfg_bot/discord/interaction_handlers.ex
@@ -15,30 +15,6 @@ defmodule LfgBot.Discord.InteractionHandlers do
   # data: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-data-structure
   # data.flags: https://discord.com/developers/docs/resources/channel#message-object-message-flags
 
-  def install_server_commands(guilds, bot_user_id) do
-    # store bot user ID in ETS for later reference
-    true = :ets.insert(:lfg_bot_table, {"bot_user_id", bot_user_id})
-
-    command = %{
-      name: Consumer.command_name(),
-      description: "Initialize LFG Bot in the current channel"
-    }
-
-    # on startup, delete all existing commands we've previously created, and re-register them.
-    # this ensures no duplicates are registered, and any command name changes are propagated to servers.
-    Enum.each(guilds, fn %{id: guild_id} ->
-      {:ok, commands} = DiscordAPI.get_guild_application_commands(guild_id)
-
-      Enum.each(commands, fn %{id: command_id} ->
-        DiscordAPI.delete_guild_application_command(guild_id, command_id)
-      end)
-
-      DiscordAPI.create_guild_application_command(guild_id, command)
-    end)
-
-    {:ok}
-  end
-
   def register_channel(%Interaction{} = interaction, guild_id, channel_id) do
     check_result = check_is_channel_registered(guild_id, channel_id)
     maybe_register_channel(check_result, interaction, guild_id, channel_id)


### PR DESCRIPTION
Migrating from **guild commands** to **global commands**.

This PR includes some temporary code that will clean up all our existing commands.

In the next PR, MIGRATION PT.2, we will introduce the code that sets up our commands in the new style.

---

This PR also moves command handling from the `Consumer` into a new module `CommandHandlers`, in anticipation that we'll add more commands in the future.